### PR TITLE
Add support for RP2040

### DIFF
--- a/src/Dali.cpp
+++ b/src/Dali.cpp
@@ -33,11 +33,11 @@
   repeat: 32-128(-143), 258, 259, 
 */
 
-void DaliClass::begin(byte tx_pin, byte rx_pin, bool active_low = true) {
+void DaliClass::begin(byte tx_pin, byte rx_pin, bool active_low) {
   DaliBus.begin(tx_pin, rx_pin, active_low);
 }
 
-int DaliClass::sendRawWait(const byte * message, byte length, byte timeout = 50) {
+int DaliClass::sendRawWait(const byte * message, byte length, byte timeout) {
   unsigned long time = millis();
   int result;
 
@@ -61,22 +61,22 @@ byte * DaliClass::prepareCmd(byte * message, byte address, byte command, byte ty
   return message;  
 }
 
-daliReturnValue DaliClass::sendArc(byte address, byte value, byte addr_type = DALI_SHORT_ADDRESS) {
+daliReturnValue DaliClass::sendArc(byte address, byte value, byte addr_type) {
   byte message[2];
   return DaliBus.sendRaw(prepareCmd(message, address, value, addr_type, 0), 2);
 }
 
-daliReturnValue DaliClass::sendArcWait(byte address, byte value, byte addr_type = DALI_SHORT_ADDRESS, byte timeout = 50) {
+daliReturnValue DaliClass::sendArcWait(byte address, byte value, byte addr_type, byte timeout) {
   byte message[2];
-  return sendRawWait(prepareCmd(message, address, value, addr_type, 0), 2, timeout);
+  return (daliReturnValue)sendRawWait(prepareCmd(message, address, value, addr_type, 0), 2, timeout);
 }
 
-daliReturnValue DaliClass::sendCmd(byte address, byte command, byte addr_type = DALI_SHORT_ADDRESS) {
+daliReturnValue DaliClass::sendCmd(byte address, byte command, byte addr_type) {
   byte message[2];
   return DaliBus.sendRaw(prepareCmd(message, address, command, addr_type, 1), 2);
 }
 
-int DaliClass::sendCmdWait(byte address, byte command, byte addr_type = DALI_SHORT_ADDRESS, byte timeout = 50) {
+int DaliClass::sendCmdWait(byte address, byte command, byte addr_type, byte timeout) {
   byte sendCount = (command > 32 && command < 143) ? 2 : 1; // config commands need to be sent twice
 
   byte message[2];
@@ -99,18 +99,18 @@ byte * DaliClass::prepareSpecialCmd(byte * message, word command, byte value) {
   return message;
 }
 
-daliReturnValue DaliClass::sendSpecialCmd(word command, byte value = 0) {
-  if (command < 256 || command > 287) return 1;
+daliReturnValue DaliClass::sendSpecialCmd(word command, byte value) {
+  if (command < 256 || command > 287) return DALI_INVALID_PARAMETER;
   byte message[2];
   return DaliBus.sendRaw(prepareSpecialCmd(message, command, value), 2);
 }
 
-int DaliClass::sendSpecialCmdWait(word command, byte value = 0, byte timeout = 50) {
+int DaliClass::sendSpecialCmdWait(word command, byte value, byte timeout) {
   byte message[2];
   return sendRawWait(prepareSpecialCmd(message, command, value), 2);
 }
 
-void DaliClass::commission(byte startAddress = 0, bool onlyNew = false) {
+void DaliClass::commission(byte startAddress, bool onlyNew) {
   nextShortAddress = startAddress;
   commissionOnlyNew = onlyNew;
   
@@ -229,5 +229,3 @@ void DaliClass::commission_tick() {
     }
   }
 }
-
-DaliClass Dali;

--- a/src/Dali.cpp
+++ b/src/Dali.cpp
@@ -229,3 +229,5 @@ void DaliClass::commission_tick() {
     }
   }
 }
+
+DaliClass Dali;

--- a/src/Dali.h
+++ b/src/Dali.h
@@ -234,6 +234,8 @@ class DaliClass {
 };
 
 /** Dali class instance for main usage (seems to be common Arduino Library style) */
+#ifndef DALI_DONT_EXPORT
 extern DaliClass Dali;
+#endif
 
 #endif // DALI_H

--- a/src/DaliBus.cpp
+++ b/src/DaliBus.cpp
@@ -21,6 +21,8 @@
   // wrapper for interrupt handler
 void DaliBus_wrapper_pinchangeISR() { DaliBus.pinchangeISR(); }
 void DaliBus_wrapper_timerISR() { DaliBus.timerISR(); }
+#else
+RPI_PICO_Timer timer2(0);
 #endif
 
 void DaliBusClass::begin(byte tx_pin, byte rx_pin, bool active_low) {
@@ -43,8 +45,8 @@ void DaliBusClass::begin(byte tx_pin, byte rx_pin, bool active_low) {
     DaliBus.pinchangeISR();
   }, CHANGE);
 
-  ITimer2 = new RPI_PICO_Timer(DALI_TIMER);
-  ITimer2->attachInterrupt(DALI_TE * 1000, [](repeating_timer *t) -> bool {
+  float frequenz = 1 / DALI_TE;
+  timer2.attachInterrupt(2398, [](repeating_timer *t) -> bool {
     DaliBus.timerISR();
     return true;
   });

--- a/src/DaliBus.h
+++ b/src/DaliBus.h
@@ -80,9 +80,6 @@ class DaliBusClass {
     bool activeLow;
     byte txMessage[3];
     byte txLength;
-#ifdef ARDUINO_ARCH_RP2040
-    RPI_PICO_Timer *ITimer2;
-#endif
 
     enum busStateEnum {
       TX_START_1ST, TX_START_2ND,

--- a/src/DaliBus.h
+++ b/src/DaliBus.h
@@ -27,10 +27,22 @@
 
 #include "Arduino.h"
 
+#ifdef ARDUINO_ARCH_RP2040
+#include "TimerInterrupt_Generic.h"
+#ifndef DALI_TIMER
+#define DALI_TIMER 2
+#warning DALI_TIMER not set; using 2 as default (valid values: 0-3)
+#else
+#if DALI_TIMER < 0 || DALI_TIMER > 3
+#error DALI_TIMER has invalid value (valid values: 0-3)
+#endif
+#endif
+#else
 // TimerOne library for tx timer
 #include "TimerOne.h"
 // PinChangeInterrupt library for rx interrupt
 #include "PinChangeInterrupt.h"
+#endif
 
 const int DALI_BAUD = 1200;
 const unsigned long DALI_TE = 417;
@@ -68,6 +80,9 @@ class DaliBusClass {
     bool activeLow;
     byte txMessage[3];
     byte txLength;
+#ifdef ARDUINO_ARCH_RP2040
+    RPI_PICO_Timer *ITimer2;
+#endif
 
     enum busStateEnum {
       TX_START_1ST, TX_START_2ND,


### PR DESCRIPTION
This PR adds support for the RP2040.
Since the RP2040 has 4 timer you can set it with the define DALI_TIMER.
Default is 2.