### PR TITLE
Feature add receiving and broadcast

### DIFF
--- a/src/Dali.cpp
+++ b/src/Dali.cpp
@@ -37,7 +37,12 @@ void DaliClass::begin(byte tx_pin, byte rx_pin, bool active_low = true) {
   DaliBus.begin(tx_pin, rx_pin, active_low);
 }
 
-int DaliClass::sendRawWait(const byte * message, byte length, byte timeout = 50) {
+void DaliClass::setCallback(EventHandlerReceivedDataFuncPtr callback)
+{
+  DaliBus.receivedCallback = callback;
+}
+
+int DaliClass::sendRawWait(const byte * message, byte length, byte timeout) {
   unsigned long time = millis();
   int result;
 
@@ -61,22 +66,38 @@ byte * DaliClass::prepareCmd(byte * message, byte address, byte command, byte ty
   return message;  
 }
 
-daliReturnValue DaliClass::sendArc(byte address, byte value, byte addr_type = DALI_SHORT_ADDRESS) {
+daliReturnValue DaliClass::sendArcBroadcast(byte value) {
+  return sendArc(0xFF, value, 1);
+}
+
+daliReturnValue DaliClass::sendArc(byte address, byte value, byte addr_type) {
   byte message[2];
   return DaliBus.sendRaw(prepareCmd(message, address, value, addr_type, 0), 2);
 }
 
-daliReturnValue DaliClass::sendArcWait(byte address, byte value, byte addr_type = DALI_SHORT_ADDRESS, byte timeout = 50) {
+daliReturnValue DaliClass::sendArcBroadcastWait(byte value, byte timeout) {
+  return sendArcWait(0xFF, value, 1, timeout);
+}
+
+daliReturnValue DaliClass::sendArcWait(byte address, byte value, byte addr_type, byte timeout) {
   byte message[2];
   return sendRawWait(prepareCmd(message, address, value, addr_type, 0), 2, timeout);
 }
 
-daliReturnValue DaliClass::sendCmd(byte address, byte command, byte addr_type = DALI_SHORT_ADDRESS) {
+daliReturnValue DaliClass::sendCmdBroadcast(byte command) {
+  return sendCmd(0xFF, command, 1);
+}
+
+daliReturnValue DaliClass::sendCmd(byte address, byte command, byte addr_type) {
   byte message[2];
   return DaliBus.sendRaw(prepareCmd(message, address, command, addr_type, 1), 2);
 }
 
-int DaliClass::sendCmdWait(byte address, byte command, byte addr_type = DALI_SHORT_ADDRESS, byte timeout = 50) {
+int DaliClass::sendCmdBroadcastWait(byte command, byte timeout) {
+  return sendCmdWait(0xFF, command, 1, timeout);
+}
+
+int DaliClass::sendCmdWait(byte address, byte command, byte addr_type, byte timeout) {
   byte sendCount = (command > 32 && command < 143) ? 2 : 1; // config commands need to be sent twice
 
   byte message[2];

--- a/src/Dali.cpp
+++ b/src/Dali.cpp
@@ -15,7 +15,7 @@
  * MA 02110-1301  USA
 */
 
-#include "dali.h"
+#include "Dali.h"
 
 /*    
     0- 31  arc power control commands

--- a/src/Dali.h
+++ b/src/Dali.h
@@ -42,7 +42,7 @@
 #define DALI_H
 
 #include <arduino.h>
-#include "dalibus.h"
+#include "DaliBus.h"
 
 /**
  * DALI library base class.

--- a/src/Dali.h
+++ b/src/Dali.h
@@ -125,6 +125,7 @@ class DaliClass {
       * It doesn't check if the bus is ready and returns immediately, stating if transmission could be
       * initiated through its response value ::daliReturnValue. */
     daliReturnValue sendArc(byte address, byte value, byte addr_type = DALI_SHORT_ADDRESS);
+    daliReturnValue sendArcBroadcast(byte value);
 
     /** Send a direct arc level command and wait for its completion
       * @param  address    destination address
@@ -135,6 +136,7 @@ class DaliClass {
       * This methods sends a "direct arc power control command" to the bus
       * It uses sendRawWait(), so it waits for the bus to become idle before and after transmission. */
     daliReturnValue sendArcWait(byte address, byte value, byte addr_type = DALI_SHORT_ADDRESS, byte timeout = 50);
+    daliReturnValue sendArcBroadcastWait(byte value, byte timeout = 50);
 
     /** Send a DALI command
       * @param  address    destination address
@@ -147,7 +149,8 @@ class DaliClass {
       * Note that some of the special commands need to be sent twice (258 - INITIALISE, 259 - RANDOMISE), which
       * this method doesn't do by itself. */
     daliReturnValue sendCmd(byte address, byte command, byte addr_type = DALI_SHORT_ADDRESS);
-    
+    daliReturnValue sendCmdBroadcast(byte command);
+
     /** Send a DALI command, wait for its completion and return the response if available
       * @param  address    destination address
       * @param  command    DALI command
@@ -155,7 +158,8 @@ class DaliClass {
       * @param  timeout    time in ms to wait for action to complete
       * @return returns either the response, DALI_RX_EMPTY or any of ::daliReturnValue on error  */
     int sendCmdWait(byte address, byte command, byte addr_type = DALI_SHORT_ADDRESS, byte timeout = 50);
-    
+    int sendCmdBroadcastWait(byte command, byte timeout = 50);
+
     /** Send a DALI special command
       * @param  command  DALI special command
       * @param  value    Value (2nd byte)
@@ -192,6 +196,10 @@ class DaliClass {
       * DALI_RX_EMPTY if no response has been received or any of ::daliReturnValue if an error has occurred. */
     int sendRawWait(const byte * message, byte length, byte timeout = 50);
 
+    /** Set Callback for receiving messages. */
+    void setCallback(EventHandlerReceivedDataFuncPtr callback);
+
+#ifndef DALI_NO_COMMISSIONING
     /** Initiate commissioning of all DALI ballasts
       * @param startAddress  address starting short address assignment from
       * @param onlyNew       commission only ballasts without short address
@@ -224,6 +232,7 @@ class DaliClass {
       COMMISSION_WITHDRAW, COMMISSION_TERMINATE
     };
     commissionStateEnum commissionState = COMMISSION_OFF; /**< current state of commissioning state machine */
+#endif
 
   protected:
     /** Prepares a byte array for sending DALI commands */

--- a/src/DaliBus.cpp
+++ b/src/DaliBus.cpp
@@ -221,7 +221,6 @@ void DaliBusClass::pinchangeISR() {
         else
           rxCommand = rxCommand << 1 | busLevel;
         rxLength += 2;
-        rxLength += 2;
       } else {
         rxLength = DALI_RX_ERROR;
         busState = RX_STOP; // timing error -> reset state

--- a/src/DaliBus.cpp
+++ b/src/DaliBus.cpp
@@ -143,7 +143,26 @@ void DaliBusClass::timerISR() {
     case RX_START:
     case RX_BIT:
       if (busIdleCount > 3) // bus has been inactive for too long
+      {
         busState = IDLE;    // rx has been interrupted, bus is idle
+        if(rxLength > 16)
+        {
+          if(receivedCallback != 0)
+          {
+            uint8_t len = (rxLength - (rxLength % 2)) / (2*8);
+            if(len > 1)
+            {
+              uint8_t *data = new uint8_t[len];
+              for(int i = 0; i < len; i++)
+                data[i] = (rxCommand >> ((len-1-i)*8)) & 0xFF;
+              receivedCallback(data, len);
+              delete[] data;
+            } else {
+              receivedCallback((uint8_t*)&rxCommand, 1);
+            }
+          }
+        }
+      }
       break;
   }
 }
@@ -171,6 +190,7 @@ void DaliBusClass::pinchangeISR() {
       if (busLevel == LOW) { // start of rx frame
         //Timer1.restart();    // sync timer
         busState = RX_START;
+        rxIsResponse = true;
       } else
         busState = IDLE; // bus can't actually be high, reset
         // TODO: log error?
@@ -188,16 +208,25 @@ void DaliBusClass::pinchangeISR() {
     case RX_BIT:
       if (isDeltaWithinTE(delta)) {              // check if change is within time of a half-bit
         if (rxLength % 2)                        // if rxLength is odd (= actual bit change)
-          rxMessage = rxMessage << 1 | busLevel; // shift in received bit
+        {
+          if(rxIsResponse)
+            rxMessage = rxMessage << 1 | busLevel;   // shift in received bit
+          else
+            rxCommand = rxCommand << 1 | busLevel;
+        }
         rxLength++;
       } else if (isDeltaWithin2TE(delta)) {       // check if change is within time of two half-bits
-        rxMessage = rxMessage << 1 | busLevel;   // shift in received bit
+        if(rxIsResponse)
+          rxMessage = rxMessage << 1 | busLevel;   // shift in received bit
+        else
+          rxCommand = rxCommand << 1 | busLevel;
+        rxLength += 2;
         rxLength += 2;
       } else {
         rxLength = DALI_RX_ERROR;
         busState = RX_STOP; // timing error -> reset state
       }
-      if (rxLength == 16) // check if all 8 bits have been received
+      if (rxIsResponse && rxLength == 16) // check if all 8 bits have been received
         busState = RX_STOP;
       break;
     case SHORT:
@@ -205,6 +234,10 @@ void DaliBusClass::pinchangeISR() {
         busState = IDLE; // recover from bus error
       break;
     case IDLE:
+      if(busLevel == LOW) {
+        busState = RX_START;
+        rxIsResponse = false;
+      }
       break;  // ignore, we didn't expect rx
   }
 }

--- a/src/DaliBus.h
+++ b/src/DaliBus.h
@@ -50,6 +50,8 @@ typedef enum daliReturnValue {
   DALI_COLLISION = -8,
 } daliReturnValue;
 
+typedef void (*EventHandlerReceivedDataFuncPtr)(uint8_t *data, uint8_t len);
+
 class DaliBusClass {
   public:
     void begin(byte tx_pin, byte rx_pin, bool active_low = true);
@@ -62,6 +64,7 @@ class DaliBusClass {
 
     void timerISR();
     void pinchangeISR();
+    EventHandlerReceivedDataFuncPtr receivedCallback;
 
   protected:
     byte txPin, rxPin;
@@ -84,8 +87,10 @@ class DaliBusClass {
 
     volatile unsigned long rxLastChange;
     volatile byte rxMessage;
+    volatile uint32_t rxCommand;
     volatile char rxLength;
     volatile char rxError;
+    volatile bool rxIsResponse = false;
 
     bool isDeltaWithinTE(unsigned long delta);
     bool isDeltaWithin2TE(unsigned long delta);


### PR DESCRIPTION
I added some functions to send broadcast arcs and cmds.

I also added the feature to receive commands/responses like described in #6 .
Example:
```C++
Dali.setCallback([](uint8_t *data, uint8_t len) -> void {
    logHexInfo("Test", data, len);
});
```
Its important to keep the code very short otherwise you will lose following commands or responses.